### PR TITLE
Work on porting zenoh_benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@
 *.exe
 *.out
 *.app
+
+# Python binaries
+__pycache__
+*.pyc
+*.pyo
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,87 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(reference_system)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake_ros REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+
+add_library(reference_system_nodes SHARED
+  src/arequipa.cpp
+  src/barcelona.cpp
+  src/geneva.cpp
+  src/georgetown.cpp
+  src/hamburg.cpp
+  src/lyon.cpp
+  src/mandalay.cpp
+  src/monaco.cpp
+  src/osaka.cpp
+  src/ponce.cpp
+  src/publisher_nodes.cpp
+  src/rotterdam.cpp
+  src/taipei.cpp
+  src/tripoli.cpp
+)
+
+ament_target_dependencies(reference_system_nodes
+  "rclcpp"
+  "rclcpp_components"
+  "geometry_msgs"
+  "std_msgs"
+  "sensor_msgs"
+)
+
+rclcpp_components_register_nodes(reference_system_nodes
+  "reference_system::Arequipa"
+  "reference_system::Barcelona"
+  "reference_system::Cordoba"
+  "reference_system::Delhi"
+  "reference_system::Freeport"
+  "reference_system::Geneva"
+  "reference_system::Georgetown"
+  "reference_system::Hamburg"
+  "reference_system::Hebron"
+  "reference_system::Kingston"
+  "reference_system::Lyon"
+  "reference_system::Osaka"
+  "reference_system::Mandalay"
+  "reference_system::Medellin"
+  "reference_system::Monaco"
+  "reference_system::Ponce"
+  "reference_system::Portsmouth"
+  "reference_system::Rotterdam"
+  "reference_system::Taipei"
+  "reference_system::Tripoli"
+)
+
+target_include_directories(reference_system_nodes PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+
+install(TARGETS
+  reference_system_nodes
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+Any contribution that you make to this repository will
+be under the Apache 2 License, as dictated by that
+[license](http://www.apache.org/licenses/LICENSE-2.0.html):
+
+~~~
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+~~~
+
+Contributors must sign-off each commit by adding a `Signed-off-by: ...`
+line to commit messages to certify that they have the right to submit
+the code they are contributing to the project according to the
+[Developer Certificate of Origin (DCO)](https://developercertificate.org/).

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/include/reference_system/arequipa.hpp
+++ b/include/reference_system/arequipa.hpp
@@ -1,0 +1,34 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef REFERENCE_SYSTEM__AREQUIPA_HPP_
+#define REFERENCE_SYSTEM__AREQUIPA_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "std_msgs/msg/string.hpp"
+
+namespace reference_system
+{
+class Arequipa : public rclcpp::Node
+{
+public:
+  explicit Arequipa(rclcpp::NodeOptions options);
+
+protected:
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr arkansas_subscription_;
+};
+}  // namespace reference_system
+
+#endif  // REFERENCE_SYSTEM__AREQUIPA_HPP_

--- a/include/reference_system/barcelona.hpp
+++ b/include/reference_system/barcelona.hpp
@@ -1,0 +1,38 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef REFERENCE_SYSTEM__BARCELONA_HPP_
+#define REFERENCE_SYSTEM__BARCELONA_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "geometry_msgs/msg/twist_with_covariance_stamped.hpp"
+#include "geometry_msgs/msg/wrench_stamped.hpp"
+
+namespace reference_system
+{
+class Barcelona : public rclcpp::Node
+{
+public:
+  explicit Barcelona(rclcpp::NodeOptions options);
+
+protected:
+  rclcpp::Subscription<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr
+    mekong_subscription_;
+
+  rclcpp::Publisher<geometry_msgs::msg::WrenchStamped>::SharedPtr lena_publisher_;
+};
+}  // namespace reference_system
+
+#endif  // REFERENCE_SYSTEM__BARCELONA_HPP_

--- a/include/reference_system/geneva.hpp
+++ b/include/reference_system/geneva.hpp
@@ -1,0 +1,41 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef REFERENCE_SYSTEM__GENEVA_HPP_
+#define REFERENCE_SYSTEM__GENEVA_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "std_msgs/msg/string.hpp"
+#include "geometry_msgs/msg/pose.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+
+namespace reference_system
+{
+class Geneva : public rclcpp::Node
+{
+public:
+  explicit Geneva(rclcpp::NodeOptions options);
+
+protected:
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr parana_subscription_;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr danube_subscription_;
+  rclcpp::Subscription<geometry_msgs::msg::Pose>::SharedPtr tagus_subscription_;
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr congo_subscription_;
+
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr arkansas_publisher_;
+};
+}  // namespace reference_system
+
+#endif  // REFERENCE_SYSTEM__GENEVA_HPP_

--- a/include/reference_system/georgetown.hpp
+++ b/include/reference_system/georgetown.hpp
@@ -1,0 +1,40 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef REFERENCE_SYSTEM__GEORGETOWN_HPP_
+#define REFERENCE_SYSTEM__GEORGETOWN_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "geometry_msgs/msg/vector3_stamped.hpp"
+#include "geometry_msgs/msg/wrench_stamped.hpp"
+#include "std_msgs/msg/float64.hpp"
+
+namespace reference_system
+{
+class Georgetown : public rclcpp::Node
+{
+public:
+  explicit Georgetown(rclcpp::NodeOptions options);
+
+protected:
+  rclcpp::Subscription<geometry_msgs::msg::Vector3Stamped>::SharedPtr murray_subscription_;
+  rclcpp::Subscription<geometry_msgs::msg::WrenchStamped>::SharedPtr lena_subscription_;
+
+  rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr volga_publisher_;
+  rclcpp::TimerBase::SharedPtr timer_;
+};
+}  // namespace reference_system
+
+#endif  // REFERENCE_SYSTEM__GEORGETOWN_HPP_

--- a/include/reference_system/hamburg.hpp
+++ b/include/reference_system/hamburg.hpp
@@ -1,0 +1,42 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef REFERENCE_SYSTEM__HAMBURG_HPP_
+#define REFERENCE_SYSTEM__HAMBURG_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "std_msgs/msg/float32.hpp"
+#include "std_msgs/msg/int32.hpp"
+#include "std_msgs/msg/int64.hpp"
+#include "std_msgs/msg/string.hpp"
+
+namespace reference_system
+{
+class Hamburg : public rclcpp::Node
+{
+public:
+  explicit Hamburg(rclcpp::NodeOptions options);
+
+protected:
+  rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr tigris_subscription_;
+  rclcpp::Subscription<std_msgs::msg::Int64>::SharedPtr ganges_subscription_;
+  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr nile_subscription_;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr danube_subscription_;
+
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr parana_publisher_;
+};
+}  // namespace reference_system
+
+#endif  // REFERENCE_SYSTEM__HAMBURG_HPP_

--- a/include/reference_system/lyon.hpp
+++ b/include/reference_system/lyon.hpp
@@ -1,0 +1,39 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef REFERENCE_SYSTEM__LYON_HPP_
+#define REFERENCE_SYSTEM__LYON_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "std_msgs/msg/float32.hpp"
+
+namespace reference_system
+{
+class Lyon : public rclcpp::Node
+{
+public:
+  explicit Lyon(rclcpp::NodeOptions options);
+
+protected:
+  using MsgType = std_msgs::msg::Float32;
+
+  void on_receive(MsgType::UniquePtr msg);
+
+  rclcpp::Subscription<MsgType>::SharedPtr subscription_;
+  rclcpp::Publisher<MsgType>::SharedPtr publisher_;
+};
+}  // namespace reference_system
+
+#endif  // REFERENCE_SYSTEM__LYON_HPP_

--- a/include/reference_system/mandalay.hpp
+++ b/include/reference_system/mandalay.hpp
@@ -1,0 +1,51 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef REFERENCE_SYSTEM__MANDALAY_HPP_
+#define REFERENCE_SYSTEM__MANDALAY_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "geometry_msgs/msg/pose.hpp"
+#include "geometry_msgs/msg/quaternion.hpp"
+#include "geometry_msgs/msg/vector3.hpp"
+#include "sensor_msgs/msg/image.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
+#include "sensor_msgs/msg/point_cloud2.hpp"
+#include "std_msgs/msg/string.hpp"
+
+namespace reference_system
+{
+class Mandalay : public rclcpp::Node
+{
+public:
+  explicit Mandalay(rclcpp::NodeOptions options);
+
+protected:
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr danube_subscription_;
+  rclcpp::Subscription<geometry_msgs::msg::Quaternion>::SharedPtr chenab_subscription_;
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr salween_subscription_;
+  rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr godavari_subscription_;
+  rclcpp::Subscription<geometry_msgs::msg::Vector3>::SharedPtr yamuna_subscription_;
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr loire_subscription_;
+
+  rclcpp::Publisher<geometry_msgs::msg::Pose>::SharedPtr tagus_publisher_;
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr missouri_publisher_;
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr brazos_publisher_;
+
+  rclcpp::TimerBase::SharedPtr timer_;
+};
+}  // namespace reference_system
+
+#endif  // REFERENCE_SYSTEM__MANDALAY_HPP_

--- a/include/reference_system/monaco.hpp
+++ b/include/reference_system/monaco.hpp
@@ -1,0 +1,37 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef REFERENCE_SYSTEM__MONACO_HPP_
+#define REFERENCE_SYSTEM__MONACO_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "geometry_msgs/msg/twist.hpp"
+#include "std_msgs/msg/float32.hpp"
+
+namespace reference_system
+{
+class Monaco : public rclcpp::Node
+{
+public:
+  explicit Monaco(rclcpp::NodeOptions options);
+
+protected:
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr congo_subscription_;
+
+  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr ohio_publisher_;
+};
+}  // namespace reference_system
+
+#endif  // REFERENCE_SYSTEM__MONACO_HPP_

--- a/include/reference_system/osaka.hpp
+++ b/include/reference_system/osaka.hpp
@@ -1,0 +1,41 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef REFERENCE_SYSTEM__OSAKA_HPP_
+#define REFERENCE_SYSTEM__OSAKA_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "sensor_msgs/msg/image.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
+#include "sensor_msgs/msg/point_cloud2.hpp"
+#include "std_msgs/msg/string.hpp"
+
+namespace reference_system
+{
+class Osaka : public rclcpp::Node
+{
+public:
+  explicit Osaka(rclcpp::NodeOptions options);
+
+protected:
+  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr colorado_subscription_;
+  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr columbia_subscription_;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr parana_subscription_;
+
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr salween_publisher_;
+  rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr godavari_publisher_;
+};
+}  // namespace reference_system
+#endif  // REFERENCE_SYSTEM__OSAKA_HPP_

--- a/include/reference_system/ponce.hpp
+++ b/include/reference_system/ponce.hpp
@@ -1,0 +1,55 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef REFERENCE_SYSTEM__PONCE_HPP_
+#define REFERENCE_SYSTEM__PONCE_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "geometry_msgs/msg/pose.hpp"
+#include "geometry_msgs/msg/quaternion.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include "geometry_msgs/msg/twist_with_covariance_stamped.hpp"
+#include "geometry_msgs/msg/vector3.hpp"
+#include "sensor_msgs/msg/image.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
+#include "sensor_msgs/msg/point_cloud2.hpp"
+#include "std_msgs/msg/string.hpp"
+#include "std_msgs/msg/float32.hpp"
+#include "std_msgs/msg/float64.hpp"
+
+namespace reference_system
+{
+class Ponce : public rclcpp::Node
+{
+public:
+  explicit Ponce(rclcpp::NodeOptions options);
+
+protected:
+  rclcpp::Subscription<geometry_msgs::msg::Pose>::SharedPtr tagus_subscription_;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr danube_subscription_;
+  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr missouri_subscription_;
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr brazos_subscription_;
+  rclcpp::Subscription<geometry_msgs::msg::Vector3>::SharedPtr yamuna_subscription_;
+  rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr godavari_subscription_;
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr loire_subscription_;
+  rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr ohio_subscription_;
+  rclcpp::Subscription<std_msgs::msg::Float64>::SharedPtr volga_subscription_;
+
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr congo_publisher_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr mekong_publisher_;
+};
+}  // namespace reference_system
+
+#endif  // REFERENCE_SYSTEM__PONCE_HPP_

--- a/include/reference_system/publisher_node.hpp
+++ b/include/reference_system/publisher_node.hpp
@@ -1,0 +1,58 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef REFERENCE_SYSTEM__PUBLISHER_NODE_HPP_
+#define REFERENCE_SYSTEM__PUBLISHER_NODE_HPP_
+
+#include <chrono>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+
+namespace reference_system
+{
+struct PublisherConfig
+{
+  std::string node_name;
+  std::string topic;
+  std::chrono::milliseconds publish_period;
+  size_t queue_depth = 10;
+};
+
+template<typename MsgType>
+class PublisherNode : public rclcpp::Node
+{
+public:
+  PublisherNode(PublisherConfig config, rclcpp::NodeOptions options)
+  : Node(config.node_name, options)
+  {
+    publisher_ = create_publisher<MsgType>(config.topic, config.queue_depth);
+    timer_ = create_wall_timer(config.publish_period, std::bind(&PublisherNode::on_timer, this));
+  }
+
+  virtual ~PublisherNode() = default;
+
+protected:
+  void on_timer()
+  {
+    MsgType msg;
+    publisher_->publish(msg);
+  }
+
+  typename rclcpp::Publisher<MsgType>::SharedPtr publisher_;
+  rclcpp::TimerBase::SharedPtr timer_;
+};
+}  // namespace reference_system
+
+#endif  // REFERENCE_SYSTEM__PUBLISHER_NODE_HPP_

--- a/include/reference_system/publisher_nodes.hpp
+++ b/include/reference_system/publisher_nodes.hpp
@@ -1,0 +1,81 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef REFERENCE_SYSTEM__PUBLISHER_NODES_HPP_
+#define REFERENCE_SYSTEM__PUBLISHER_NODES_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+#include "reference_system/publisher_node.hpp"
+
+#include "geometry_msgs/msg/quaternion.hpp"
+#include "geometry_msgs/msg/vector3.hpp"
+#include "std_msgs/msg/float32.hpp"
+#include "std_msgs/msg/int32.hpp"
+#include "std_msgs/msg/int64.hpp"
+#include "std_msgs/msg/string.hpp"
+#include "sensor_msgs/msg/image.hpp"
+
+namespace reference_system
+{
+
+class Cordoba final : public PublisherNode<std_msgs::msg::Float32>
+{
+public:
+  Cordoba(rclcpp::NodeOptions options);
+  ~Cordoba() final = default;
+};
+
+class Freeport final : public PublisherNode<std_msgs::msg::Int64>
+{
+public:
+  Freeport(rclcpp::NodeOptions options);
+  ~Freeport() final = default;
+};
+
+class Medellin final : public PublisherNode<std_msgs::msg::Int32>
+{
+public:
+  Medellin(rclcpp::NodeOptions options);
+  ~Medellin() final = default;
+};
+
+class Portsmouth final : public PublisherNode<std_msgs::msg::String>
+{
+public:
+  Portsmouth(rclcpp::NodeOptions options);
+  ~Portsmouth() final = default;
+};
+
+class Delhi final : public PublisherNode<sensor_msgs::msg::Image>
+{
+public:
+  Delhi(rclcpp::NodeOptions options);
+  ~Delhi() final = default;
+};
+
+class Hebron final : public PublisherNode<geometry_msgs::msg::Quaternion>
+{
+public:
+  Hebron(rclcpp::NodeOptions options);
+  ~Hebron() final = default;
+};
+
+class Kingston final : public PublisherNode<geometry_msgs::msg::Vector3>
+{
+public:
+  Kingston(rclcpp::NodeOptions options);
+  ~Kingston() final = default;
+};
+}  // namespace reference_system
+#endif  // REFERENCE_SYSTEM__PUBLISHER_NODES_HPP_

--- a/include/reference_system/rotterdam.hpp
+++ b/include/reference_system/rotterdam.hpp
@@ -1,0 +1,38 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef REFERENCE_SYSTEM__ROTTERDAM_HPP_
+#define REFERENCE_SYSTEM__ROTTERDAM_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "geometry_msgs/msg/twist_with_covariance_stamped.hpp"
+#include "geometry_msgs/msg/vector3_stamped.hpp"
+
+namespace reference_system
+{
+class Rotterdam : public rclcpp::Node
+{
+public:
+  explicit Rotterdam(rclcpp::NodeOptions options);
+
+protected:
+  rclcpp::Subscription<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr
+    mekong_subscription_;
+
+  rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr murray_publisher_;
+};
+}  // namespace reference_system
+
+#endif  // REFERENCE_SYSTEM__ROTTERDAM_HPP_

--- a/include/reference_system/taipei.hpp
+++ b/include/reference_system/taipei.hpp
@@ -1,0 +1,38 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef REFERENCE_SYSTEM__TAIPEI_HPP_
+#define REFERENCE_SYSTEM__TAIPEI_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "sensor_msgs/msg/image.hpp"
+
+namespace reference_system
+{
+class Taipei : public rclcpp::Node
+{
+public:
+  explicit Taipei(rclcpp::NodeOptions options);
+
+protected:
+  using MsgType = sensor_msgs::msg::Image;
+
+  void on_receive(MsgType::UniquePtr msg);
+
+  rclcpp::Subscription<MsgType>::SharedPtr subscription_;
+  rclcpp::Publisher<MsgType>::SharedPtr publisher_;
+};
+}  // namespace reference_system
+#endif  // REFERENCE_SYSTEM__TAIPEI_HPP_

--- a/include/reference_system/tripoli.hpp
+++ b/include/reference_system/tripoli.hpp
@@ -1,0 +1,39 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef REFERENCE_SYSTEM__TRIPOLI_HPP_
+#define REFERENCE_SYSTEM__TRIPOLI_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "sensor_msgs/msg/image.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
+#include "sensor_msgs/msg/point_cloud2.hpp"
+#include "std_msgs/msg/string.hpp"
+
+namespace reference_system
+{
+class Tripoli : public rclcpp::Node
+{
+public:
+  explicit Tripoli(rclcpp::NodeOptions options);
+
+protected:
+  rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr godavari_subscription_;
+  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr columbia_subscription_;
+
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr loire_publisher_;
+};
+}  // namespace reference_system
+#endif  // REFERENCE_SYSTEM__TRIPOLI_HPP_

--- a/launch/reference_system.launch.py
+++ b/launch/reference_system.launch.py
@@ -1,0 +1,124 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Launch a talker and a listener in a component container."""
+
+import launch
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+
+
+def generate_launch_description():
+    """Generate launch description with multiple components."""
+    robot_container = ComposableNodeContainer(
+            name='reference_system_robot',
+            namespace='',
+            package='rclcpp_components',
+            executable='component_container',
+            composable_node_descriptions=[
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Cordoba',
+                ),
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Freeport',
+                ),
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Medellin',
+                ),
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Portsmouth',
+                ),
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Delhi',
+                ),
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Taipei',
+                ),
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Lyon',
+                ),
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Hebron',
+                ),
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Kingston',
+                ),
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Hamburg',
+                ),
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Osaka',
+                ),
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Tripoli',
+                ),
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Mandalay',
+                ),
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Ponce',
+                ),
+            ],
+            output='screen',
+    )
+
+    control_container = ComposableNodeContainer(
+            name='reference_system_control',
+            namespace='',
+            package='rclcpp_components',
+            executable='component_container',
+            composable_node_descriptions=[
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Geneva',
+                ),
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Monaco',
+                ),
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Rotterdam',
+                ),
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Barcelona',
+                ),
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Arequipa',
+                ),
+                ComposableNode(
+                    package='reference_system',
+                    plugin='reference_system::Georgetown',
+                ),
+            ],
+            output='screen',
+    )
+
+    return launch.LaunchDescription([robot_container, control_container])

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>reference_system</name>
+  <version>0.0.1</version>
+  <description>Package containing a set of reference nodes</description>
+
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <author email="michael@openrobotics.org">Michael Carroll</author>
+
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+
+  <build_depend>rclcpp</build_depend>
+  <build_depend>rclcpp_components</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/arequipa.cpp
+++ b/src/arequipa.cpp
@@ -1,0 +1,33 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reference_system/arequipa.hpp"
+
+namespace reference_system
+{
+
+Arequipa::Arequipa(rclcpp::NodeOptions options)
+: Node("arequipa", options)
+{
+  arkansas_subscription_ = create_subscription<std_msgs::msg::String>(
+    "arkansas",
+    10,
+    [](std_msgs::msg::String::UniquePtr msg) {
+      (void) msg;
+    });
+}
+}  // namespace reference_system
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Arequipa)

--- a/src/barcelona.cpp
+++ b/src/barcelona.cpp
@@ -1,0 +1,37 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reference_system/barcelona.hpp"
+
+namespace reference_system
+{
+
+Barcelona::Barcelona(rclcpp::NodeOptions options)
+: Node("barcelona", options)
+{
+  lena_publisher_ = create_publisher<geometry_msgs::msg::WrenchStamped>("lena", 10);
+
+  mekong_subscription_ = create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>(
+    "mekong",
+    10,
+    [this](geometry_msgs::msg::TwistWithCovarianceStamped::UniquePtr msg) {
+      (void) msg;
+      geometry_msgs::msg::WrenchStamped pub_msg;
+      lena_publisher_->publish(pub_msg);
+    });
+}
+}  // namespace reference_system
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Barcelona)

--- a/src/geneva.cpp
+++ b/src/geneva.cpp
@@ -1,0 +1,55 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reference_system/geneva.hpp"
+
+namespace reference_system
+{
+Geneva::Geneva(rclcpp::NodeOptions options)
+: Node("geneva", options)
+{
+  arkansas_publisher_ = create_publisher<std_msgs::msg::String>("arkansas", 10);
+
+  parana_subscription_ = create_subscription<std_msgs::msg::String>(
+    "parana",
+    10,
+    [this](std_msgs::msg::String::UniquePtr msg) {
+      arkansas_publisher_->publish(std::move(msg));
+    });
+
+  danube_subscription_ = create_subscription<std_msgs::msg::String>(
+    "danube",
+    10,
+    [](std_msgs::msg::String::UniquePtr msg) {
+      (void) msg;
+    });
+
+  tagus_subscription_ = create_subscription<geometry_msgs::msg::Pose>(
+    "tagus",
+    10,
+    [](geometry_msgs::msg::Pose::UniquePtr msg) {
+      (void) msg;
+    });
+
+  congo_subscription_ = create_subscription<geometry_msgs::msg::Twist>(
+    "congo",
+    10,
+    [](geometry_msgs::msg::Twist::UniquePtr msg) {
+      (void) msg;
+    });
+}
+}  // namespace reference_system
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Geneva)

--- a/src/georgetown.cpp
+++ b/src/georgetown.cpp
@@ -1,0 +1,48 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reference_system/georgetown.hpp"
+
+namespace reference_system
+{
+
+Georgetown::Georgetown(rclcpp::NodeOptions options)
+: Node("georgetown", options)
+{
+  volga_publisher_ = create_publisher<std_msgs::msg::Float64>("volga", 10);
+
+  murray_subscription_ = create_subscription<geometry_msgs::msg::Vector3Stamped>(
+    "murray",
+    10,
+    [](geometry_msgs::msg::Vector3Stamped::UniquePtr msg) {
+      (void) msg;
+    });
+
+  lena_subscription_ = create_subscription<geometry_msgs::msg::WrenchStamped>(
+    "lena",
+    10,
+    [](geometry_msgs::msg::WrenchStamped::UniquePtr msg) {
+      (void) msg;
+    });
+
+  timer_ = create_wall_timer(
+    std::chrono::milliseconds(50), [this]() {
+      std_msgs::msg::Float64 msg;
+      this->volga_publisher_->publish(msg);
+    });
+}
+}  // namespace reference_system
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Georgetown)

--- a/src/hamburg.cpp
+++ b/src/hamburg.cpp
@@ -1,0 +1,57 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reference_system/hamburg.hpp"
+
+namespace reference_system
+{
+
+Hamburg::Hamburg(rclcpp::NodeOptions options)
+: Node("hamburg", options)
+{
+  parana_publisher_ = create_publisher<std_msgs::msg::String>("parana", 10);
+
+  tigris_subscription_ = create_subscription<std_msgs::msg::Float32>(
+    "tigris",
+    10,
+    [](std_msgs::msg::Float32::UniquePtr msg) {
+      (void) msg;
+    });
+
+  ganges_subscription_ = create_subscription<std_msgs::msg::Int64>(
+    "ganges",
+    10,
+    [](std_msgs::msg::Int64::UniquePtr msg) {
+      (void) msg;
+    });
+
+  nile_subscription_ = create_subscription<std_msgs::msg::Int32>(
+    "nile",
+    10,
+    [](std_msgs::msg::Int32::UniquePtr msg) {
+      (void) msg;
+    });
+
+  danube_subscription_ = create_subscription<std_msgs::msg::String>(
+    "danube",
+    10,
+    [this](std_msgs::msg::String::UniquePtr msg) {
+      this->parana_publisher_->publish(std::move(msg));
+    });
+}
+
+}  // namespace reference_system
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Hamburg)

--- a/src/lyon.cpp
+++ b/src/lyon.cpp
@@ -1,0 +1,40 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reference_system/lyon.hpp"
+
+namespace reference_system
+{
+
+Lyon::Lyon(rclcpp::NodeOptions options)
+: Node("lyon", options)
+{
+  publisher_ = create_publisher<MsgType>("tigris", 10);
+  subscription_ = create_subscription<MsgType>(
+    "amazon",
+    10,
+    [this](MsgType::UniquePtr msg) {
+      this->on_receive(std::move(msg));
+    });
+}
+
+void Lyon::on_receive(MsgType::UniquePtr msg)
+{
+  publisher_->publish(std::move(msg));
+}
+
+}  // namespace reference_system
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Lyon)

--- a/src/mandalay.cpp
+++ b/src/mandalay.cpp
@@ -1,0 +1,90 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reference_system/mandalay.hpp"
+
+namespace reference_system
+{
+
+Mandalay::Mandalay(rclcpp::NodeOptions options)
+: Node("mandalay", options)
+{
+  tagus_publisher_ = create_publisher<geometry_msgs::msg::Pose>("tagus", 10);
+  missouri_publisher_ = create_publisher<sensor_msgs::msg::Image>("missouri", 10);
+  brazos_publisher_ = create_publisher<sensor_msgs::msg::PointCloud2>("brazos", 10);
+
+  danube_subscription_ = create_subscription<std_msgs::msg::String>(
+    "danube",
+    10,
+    [](std_msgs::msg::String::UniquePtr msg) {
+      (void) msg;
+    });
+
+  chenab_subscription_ = create_subscription<geometry_msgs::msg::Quaternion>(
+    "chenab",
+    10,
+    [](geometry_msgs::msg::Quaternion::UniquePtr msg) {
+      (void) msg;
+    });
+
+  salween_subscription_ = create_subscription<sensor_msgs::msg::PointCloud2>(
+    "salween",
+    10,
+    [](sensor_msgs::msg::PointCloud2::UniquePtr msg) {
+      (void) msg;
+    });
+
+  godavari_subscription_ = create_subscription<sensor_msgs::msg::LaserScan>(
+    "godavari",
+    10,
+    [](sensor_msgs::msg::LaserScan::UniquePtr msg) {
+      (void) msg;
+    });
+
+  yamuna_subscription_ = create_subscription<geometry_msgs::msg::Vector3>(
+    "yamuna",
+    10,
+    [](geometry_msgs::msg::Vector3::UniquePtr msg) {
+      (void) msg;
+    });
+
+  loire_subscription_ = create_subscription<sensor_msgs::msg::PointCloud2>(
+    "loire",
+    10,
+    [](sensor_msgs::msg::PointCloud2::UniquePtr msg) {
+      (void) msg;
+    });
+
+
+  timer_ = create_wall_timer(
+    std::chrono::milliseconds(100), [this]() {
+      {
+        geometry_msgs::msg::Pose msg;
+        tagus_publisher_->publish(msg);
+      }
+      {
+        sensor_msgs::msg::Image msg;
+        missouri_publisher_->publish(msg);
+      }
+      {
+        sensor_msgs::msg::PointCloud2 msg;
+        brazos_publisher_->publish(msg);
+      }
+    });
+}
+
+}  // namespace reference_system
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Mandalay)

--- a/src/monaco.cpp
+++ b/src/monaco.cpp
@@ -1,0 +1,37 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reference_system/monaco.hpp"
+
+namespace reference_system
+{
+
+Monaco::Monaco(rclcpp::NodeOptions options)
+: Node("monaco", options)
+{
+  ohio_publisher_ = create_publisher<std_msgs::msg::Float32>("ohio", 10);
+
+  congo_subscription_ = create_subscription<geometry_msgs::msg::Twist>(
+    "congo",
+    10,
+    [this](geometry_msgs::msg::Twist::UniquePtr msg) {
+      (void) msg;
+      std_msgs::msg::Float32 pub_msg;
+      ohio_publisher_->publish(pub_msg);
+    });
+}
+}  // namespace reference_system
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Monaco)

--- a/src/osaka.cpp
+++ b/src/osaka.cpp
@@ -1,0 +1,55 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reference_system/osaka.hpp"
+
+namespace reference_system
+{
+
+Osaka::Osaka(rclcpp::NodeOptions options)
+: Node("osaka", options)
+{
+  salween_publisher_ = create_publisher<sensor_msgs::msg::PointCloud2>("salween", 10);
+  godavari_publisher_ = create_publisher<sensor_msgs::msg::LaserScan>("godavari", 10);
+
+  parana_subscription_ = create_subscription<std_msgs::msg::String>(
+    "parana",
+    10,
+    [](std_msgs::msg::String::UniquePtr msg) {
+      (void) msg;
+    });
+
+  columbia_subscription_ = create_subscription<sensor_msgs::msg::Image>(
+    "columbia",
+    10,
+    [](sensor_msgs::msg::Image::UniquePtr msg) {
+      (void) msg;
+    });
+
+  colorado_subscription_ = create_subscription<sensor_msgs::msg::Image>(
+    "colorado",
+    10,
+    [this](sensor_msgs::msg::Image::UniquePtr msg) {
+      (void) msg;
+      sensor_msgs::msg::PointCloud2 pc_msg;
+      sensor_msgs::msg::LaserScan scan_msg;
+      salween_publisher_->publish(pc_msg);
+      godavari_publisher_->publish(scan_msg);
+    });
+}
+
+}  // namespace reference_system
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Osaka)

--- a/src/ponce.cpp
+++ b/src/ponce.cpp
@@ -1,0 +1,97 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reference_system/ponce.hpp"
+
+namespace reference_system
+{
+
+Ponce::Ponce(rclcpp::NodeOptions options)
+: Node("ponce", options)
+{
+  congo_publisher_ = create_publisher<geometry_msgs::msg::Twist>("congo", 10);
+  mekong_publisher_ =
+    create_publisher<geometry_msgs::msg::TwistWithCovarianceStamped>("mekong", 10);
+
+  tagus_subscription_ = create_subscription<geometry_msgs::msg::Pose>(
+    "tagus",
+    10,
+    [](geometry_msgs::msg::Pose::UniquePtr msg) {
+      (void) msg;
+    });
+
+  danube_subscription_ = create_subscription<std_msgs::msg::String>(
+    "danube",
+    10,
+    [](std_msgs::msg::String::UniquePtr msg) {
+      (void) msg;
+    });
+
+  missouri_subscription_ = create_subscription<sensor_msgs::msg::Image>(
+    "missouri",
+    10,
+    [](sensor_msgs::msg::Image::UniquePtr msg) {
+      (void) msg;
+    });
+
+  brazos_subscription_ = create_subscription<sensor_msgs::msg::PointCloud2>(
+    "brazos",
+    10,
+    [this](sensor_msgs::msg::PointCloud2::UniquePtr msg) {
+      (void) msg;
+      auto cmd = geometry_msgs::msg::TwistWithCovarianceStamped();
+      this->congo_publisher_->publish(cmd.twist.twist);
+      this->mekong_publisher_->publish(cmd);
+    });
+
+  yamuna_subscription_ = create_subscription<geometry_msgs::msg::Vector3>(
+    "yamuna",
+    10,
+    [](geometry_msgs::msg::Vector3::UniquePtr msg) {
+      (void) msg;
+    });
+
+  godavari_subscription_ = create_subscription<sensor_msgs::msg::LaserScan>(
+    "godavari",
+    10,
+    [](sensor_msgs::msg::LaserScan::UniquePtr msg) {
+      (void) msg;
+    });
+
+  loire_subscription_ = create_subscription<sensor_msgs::msg::PointCloud2>(
+    "loire",
+    10,
+    [](sensor_msgs::msg::PointCloud2::UniquePtr msg) {
+      (void) msg;
+    });
+
+  ohio_subscription_ = create_subscription<std_msgs::msg::Float32>(
+    "ohio",
+    10,
+    [](std_msgs::msg::Float32::UniquePtr msg) {
+      (void) msg;
+    });
+
+  volga_subscription_ = create_subscription<std_msgs::msg::Float64>(
+    "volga",
+    10,
+    [](std_msgs::msg::Float64::UniquePtr msg) {
+      (void) msg;
+    });
+}
+
+}  // namespace reference_system
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Ponce)

--- a/src/publisher_nodes.cpp
+++ b/src/publisher_nodes.cpp
@@ -1,0 +1,116 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reference_system/publisher_nodes.hpp"
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+auto kCordobaConfig = reference_system::PublisherConfig(
+{
+  "cordoba",
+  "amazon",
+  std::chrono::milliseconds(100),
+});
+
+auto kFreeportConfig = reference_system::PublisherConfig(
+{
+  "freeport",
+  "ganges",
+  std::chrono::milliseconds(50),
+});
+
+auto kMedellinConfig = reference_system::PublisherConfig(
+{
+  "medellin",
+  "nile",
+  std::chrono::milliseconds(10),
+});
+
+auto kPortsmouthConfig = reference_system::PublisherConfig(
+{
+  "portsmouth",
+  "danube",
+  std::chrono::milliseconds(200),
+});
+
+auto kDelhiConfig = reference_system::PublisherConfig(
+{
+  "delhi",
+  "columbia",
+  std::chrono::milliseconds(1000),
+});
+
+auto kHebronConfig = reference_system::PublisherConfig(
+{
+  "hebron",
+  "chenab",
+  std::chrono::milliseconds(100),
+});
+
+auto kKingstonConfig = reference_system::PublisherConfig(
+{
+  "kingston",
+  "yamuna",
+  std::chrono::milliseconds(100),
+});
+
+namespace reference_system
+{
+
+Cordoba::Cordoba(rclcpp::NodeOptions options)
+: PublisherNode(kCordobaConfig, options)
+{
+}
+
+Freeport::Freeport(rclcpp::NodeOptions options)
+: PublisherNode(kFreeportConfig, options)
+{
+}
+
+Medellin::Medellin(rclcpp::NodeOptions options)
+: PublisherNode(kMedellinConfig, options)
+{
+}
+
+Portsmouth::Portsmouth(rclcpp::NodeOptions options)
+: PublisherNode(kPortsmouthConfig, options)
+{
+}
+
+Delhi::Delhi(rclcpp::NodeOptions options)
+: PublisherNode(kDelhiConfig, options)
+{
+}
+
+Hebron::Hebron(rclcpp::NodeOptions options)
+: PublisherNode(kHebronConfig, options)
+{
+}
+
+Kingston::Kingston(rclcpp::NodeOptions options)
+: PublisherNode(kKingstonConfig, options)
+{
+}
+}  // namespace reference_system
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Cordoba)
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Freeport)
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Medellin)
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Portsmouth)
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Delhi)
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Hebron)
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Kingston)

--- a/src/rotterdam.cpp
+++ b/src/rotterdam.cpp
@@ -1,0 +1,37 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reference_system/rotterdam.hpp"
+
+namespace reference_system
+{
+
+Rotterdam::Rotterdam(rclcpp::NodeOptions options)
+: Node("rotterdam", options)
+{
+  murray_publisher_ = create_publisher<geometry_msgs::msg::Vector3Stamped>("murray", 10);
+
+  mekong_subscription_ = create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>(
+    "mekong",
+    10,
+    [this](geometry_msgs::msg::TwistWithCovarianceStamped::UniquePtr msg) {
+      (void) msg;
+      geometry_msgs::msg::Vector3Stamped pub_msg;
+      murray_publisher_->publish(pub_msg);
+    });
+}
+}  // namespace reference_system
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Rotterdam)

--- a/src/taipei.cpp
+++ b/src/taipei.cpp
@@ -1,0 +1,40 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reference_system/taipei.hpp"
+
+namespace reference_system
+{
+
+Taipei::Taipei(rclcpp::NodeOptions options)
+: Node("taipei", options)
+{
+  publisher_ = create_publisher<MsgType>("colorado", 10);
+  subscription_ = create_subscription<MsgType>(
+    "columbia",
+    10,
+    [this](MsgType::UniquePtr msg) {
+      this->on_receive(std::move(msg));
+    });
+}
+
+void Taipei::on_receive(MsgType::UniquePtr msg)
+{
+  publisher_->publish(std::move(msg));
+}
+
+}  // namespace reference_system
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Taipei)

--- a/src/tripoli.cpp
+++ b/src/tripoli.cpp
@@ -1,0 +1,44 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reference_system/tripoli.hpp"
+
+namespace reference_system
+{
+
+Tripoli::Tripoli(rclcpp::NodeOptions options)
+: Node("tripoli", options)
+{
+  loire_publisher_ = create_publisher<sensor_msgs::msg::PointCloud2>("loire", 10);
+
+  godavari_subscription_ = create_subscription<sensor_msgs::msg::LaserScan>(
+    "godavari",
+    10,
+    [this](sensor_msgs::msg::LaserScan::UniquePtr msg) {
+      (void) msg;
+      sensor_msgs::msg::PointCloud2 pc_msg;
+      loire_publisher_->publish(pc_msg);
+    });
+
+  columbia_subscription_ = create_subscription<sensor_msgs::msg::Image>(
+    "columbia",
+    10,
+    [](sensor_msgs::msg::Image::UniquePtr msg) {
+      (void) msg;
+    });
+}
+}  // namespace reference_system
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(reference_system::Tripoli)


### PR DESCRIPTION
Create a set of reference system benchmark nodes that enhance https://github.com/irobot-ros/ros2-performance to also include:

A) real ROS message types
B) Publishers that require inbound subscriptions (for tracing).

This is inspired by @gbiggs work in using the iRobot topology in zenoh benchmarks https://github.com/osrf/zenoh_evaluation


# Nodes

- [x] **cordoba**
  
  - pub: `Float32` to **/amazon** every 100ms

- [x] **lyon**
  
  - sub: `Float32` **/amazon***
  - 
  - pub: `Float32` to **/tigris** on receive **/amazon**

- [x] **freeport**
  
  - pub: `Int64` to **/ganges** every 50ms

- [x] **medellin**
  
  - pub: `Int32` to **/nile** every 10ms

- [x] **portsmouth**
  
  - pub: `String` to **/danube** every 200ms (len 256)

- [x] **hamburg**
  
  - sub: `Float32` **/tigris**
  
  - sub: `Int64` **/ganges**
  
  - sub: `Int32` **/nile**
  
  - sub: `String` **/danube**
  
  - 
  
  - pub: same `String` to **/parana** on receive **/danube**

- [x] **delhi**
  
  - pub: `Image` to **/columbia** every 1000ms

- [x] **taipei**
  
  - sub: `Image` **/columbia**
  - 
  - pub: same `Image` to **/colorado** on receive **/columbia**

- [x] **osaka**
  
  - sub: `String` **/parana**
  
  - sub: `Image` **/columbia**
  
  - sub: `Image` **/colorado**
  
  - 
  
  - pub: `PointCloud2` to **/salween** on receive **/colorado**
  
  - pub: `LaserScan` to **/godavari** on receive **/colorado**

- [x] **hebron**
  
  - pub: `Quaternion` to **/chenab** every 100ms

- [x] **kingston**
  
  - pub: `Vector3` to **/yamuna** every 100ms

- [x] **tripoli**
  
  - sub: `LaserScan` **/godavari**
  
  - sub: `Image` **/columbia**
  
  - 
  
  - pub: `PointCloud2` to **/loire** on receive **/godavari**

- [x] **mandalay**
  
  - sub: `String` **/danube**
  
  - sub: `Quaternion` **/chenab**
  
  - sub: `PointCloud2` **/salween**
  
  - sub: `LaserScan` **/godavari**
  
  - sub: `Vector3` **/yamuna**
  
  - sub: `PointCloud2` **/loire**
  
  - 
  
  - pub: `Pose` to **/tagus** every 100ms
  
  - pub: `Image` to **/missouri** every 100ms
  
  - pub: `PointCloud2` to **/brazos** every 100ms

- [x] **ponce**
  
  - sub: `Pose` **/tagus**
  
  - sub: `String` **/danube**
  
  - sub: `Image` **/missouri**
  
  - sub: `PointCloud2` **/brazos**
  
  - sub: `Vector3` **/yamuna**
  
  - sub: `LaserScan` **/godavari**
  
  - sub: `PointCloud2` **/loire**
  
  - sub: `Float32` **/ohio**
  
  - sub: `Float64` **/volga**
  
  - 
  
  - pub: `Twist` to **/congo** on receive **/brazos**
  
  - pub: `TwistWithCovarianceStamped` to **/mekong** on receive **/brazos**

- [x] **geneva**
  
  - sub: `String` **/parana**
  
  - sub: `String` **/danube**
  
  - sub: `Pose` **/tagus**
  
  - sub: `Twist` **/congo**
  
  - 
  
  - pub: `String` to **/arkansas** on receive **/parana**

- [x] **monaco**
  
  - sub: `Twist` **/congo**
  
  - 
  
  - pub: `Float32` to **/ohio** on receive **/congo**

- [x] **rotterdam**
  
  - sub: `TwistWithCovarianceStamped` **/mekong**
  
  - 
  
  - pub: `Vector3Stamped` to **/murray** on receive **/mekong**

- [x] **barcelona**
  
  - sub: `TwistWithCovarianceStamped` **/mekong**
  
  - 
  
  - pub: `WrenchStamped` to **/lena** on receive **/mekong**

- [x] **arequipa**
  
  - sub: `String` **/arkansas**

- [ ] **georgetown**
  
  - sub: `Vector3Stamped` **/murray**
  
  - sub: `WrenchStamped` **/lena**
  
  - 
  
  - pub: `Float64` to **/volga** every 50ms


Signed-off-by: Michael Carroll <michael@openrobotics.org>